### PR TITLE
Revert "Chore: Add KubeCon NA 2025 to Announcement banner (#113)"

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -81,22 +81,16 @@ const Header = ({ whiteHeader, transparentMenu }) => {
         <div className={styles.newsBar}>
 
           <span className='hide-not-desktop'>
-          🎉️ Meet us in Atlanta for KubeCon + CloudNativeCon North America · Nov 10-13 ·
+            Export Pixie data in the OpenTelemetry format.
             {' '}
-            <a href='https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=px-dev&utm_medium=homepage&utm_campaign=10608228-KubeCon-NA-2025&utm_content=hero' target='_blank' rel='noreferrer'>
-            Register Today!
+            <a href='http://blog.px.dev/plugin-system/' target='_blank' rel='noreferrer'>
+              Learn more
             </a>
             {' '}
-            🥳️
+             🚀
           </span>
           <span className='hide-desktop'>
-          🎉️ Meet us in Atlanta for KubeCon + CloudNativeCon North America · Nov 10-13 ·
-            {' '}
-            <a href='https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/register/?utm_source=px-dev&utm_medium=homepage&utm_campaign=10608228-KubeCon-NA-2025&utm_content=hero' target='_blank' rel='noreferrer'>
-            Register Today!
-            </a>
-            {' '}
-            🥳️
+            <a href='http://blog.px.dev/plugin-system/' target='_blank' rel='noreferrer'>Pixie has an OpenTelemetry plugin!</a>
           </span>
           <div
             className={`${styles.newsBarClose} hide-desktop`}


### PR DESCRIPTION
Now that KubeCon is over, let's revert the banner to the previous one.